### PR TITLE
fix: update star history chart so it renders again

### DIFF
--- a/README.md
+++ b/README.md
@@ -743,7 +743,7 @@ Stay updated and join our community:
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=CursorTouch/Windows-MCP&type=Date)](https://www.star-history.com/#CursorTouch/Windows-MCP&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=CursorTouch/Windows-MCP&type=Date)](https://star-history.dera.page/#CursorTouch/Windows-MCP&Date)
 
 ## 👥 Contributors
 


### PR DESCRIPTION
The star history chart in the README is currently broken. The image fails to render because the upstream service relies on GitHub stargazer API, which now restricts token-less requests, breaking the chart. Update both the image and its link to use star-history.dera.page, an alternative that serves the same chart from a different data source and needs no API token.