### PR TITLE
fix(snapshot): restore missing view imports

### DIFF
--- a/src/windows_mcp/desktop/service.py
+++ b/src/windows_mcp/desktop/service.py
@@ -8,8 +8,8 @@ from windows_mcp.vdm.core import (
     get_current_desktop,
     is_window_on_current_desktop,
 )
-from windows_mcp.desktop.views import DesktopState, Window, Browser, Status, Size
-from windows_mcp.tree.views import BoundingBox, TreeElementNode, TreeState
+from windows_mcp.desktop.views import DesktopState, Window, Browser, Status, Size, Display
+from windows_mcp.tree.views import BoundingBox, TreeElementNode, TreeState, SemanticNode
 from PIL import ImageFont, ImageDraw, Image
 from windows_mcp.tree.service import Tree
 from windows_mcp.desktop import screenshot as screenshot_capture


### PR DESCRIPTION
## Summary
- Restore the `Display` and `SemanticNode` imports accidentally removed by #378.
- Fix `Snapshot` / `Screenshot` failures caused by `NameError: name 'Display' is not defined`.
- Restore the semantic display-filtering path that also depends on `SemanticNode`.

## Regression
`Desktop.get_displays()` still discovers the monitors correctly; the failure occurs when converting display data into the view model because `Display` is no longer imported. Existing snapshot display-filter tests also exercise both missing symbols.

Regression introduced by #378 (`dc6d06c`).

## Testing
- `uv run --frozen --extra dev pytest -q` → 495 passed
- `uv run --frozen --extra dev pytest tests/test_snapshot_display_filter.py -q` → 22 passed
- `uv run --frozen --extra dev ruff check src/windows_mcp/desktop/service.py` → passed
- `git diff --check` → passed
- Verified `_display_to_view` against the local two-display setup