### PR TITLE
docs: add optional HOL Guard protection for Cursor MCP calls

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -77,6 +77,42 @@ If you must use Windows-MCP on a regular system:
 5. **Disable High-Risk Tools**: Remove or restrict access to Shell and other destructive tools
 6. **Test First**: Thoroughly test workflows in a safe environment before production use
 
+### Optional pre-execution protection with HOL Guard (Cursor)
+
+When Windows-MCP is used from Cursor, [HOL Guard](https://github.com/hashgraph-online/hol-guard) can add a local pre-execution policy boundary before Cursor sends MCP tool calls to this server. This is an optional defense-in-depth layer; it does not replace least privilege, isolation, backups, or Windows-MCP's own access controls.
+
+1. Install HOL Guard:
+
+   ```shell
+   pipx install hol-guard
+   ```
+
+2. Configure Windows-MCP in the Cursor project as `.cursor/mcp.json`:
+
+   ```json
+   {
+     "mcpServers": {
+       "windows-mcp": {
+         "command": "uvx",
+         "args": ["windows-mcp", "serve"]
+       }
+     }
+   }
+   ```
+
+3. Install HOL Guard's Cursor protection and verify the harness:
+
+   ```shell
+   hol-guard install cursor
+   hol-guard doctor cursor
+   ```
+
+4. Restart Cursor so its MCP configuration and hooks reload.
+
+HOL Guard's current Cursor integration installs `beforeMCPExecution` with fail-closed behavior plus related pre-tool hooks. If Guard returns a deny decision for a Cursor MCP invocation, Cursor blocks that invocation before the corresponding Windows-MCP tool call executes. This protection applies to supported Cursor agent-hook paths; commands or actions launched outside the Cursor agent loop are outside this boundary.
+
+For the exact current coverage and limitations, see HOL Guard's [Cursor protection contract](https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/cursor-local-cloud-contract.md) and [setup guide](https://github.com/hashgraph-online/hol-guard/blob/main/docs/guard/get-started.md).
+
 ## Security Considerations
 
 ### System Access Level


### PR DESCRIPTION
## Description

Documents an optional [HOL Guard](https://github.com/hashgraph-online/hol-guard) pre-execution protection path for Windows-MCP when it is used from Cursor.

The SECURITY.md addition:
- installs HOL Guard with `pipx install hol-guard`;
- uses Windows-MCP's existing `uvx windows-mcp serve` configuration in `.cursor/mcp.json`;
- enables Guard's Cursor integration with `hol-guard install cursor` and verifies it with `hol-guard doctor cursor`;
- explains that a Guard deny on Cursor's `beforeMCPExecution` path blocks the MCP invocation before the corresponding Windows-MCP tool call executes;
- explicitly limits the claim to supported Cursor agent-hook paths and keeps Windows-MCP's existing isolation/least-privilege guidance intact.

## Motivation

Windows-MCP's security policy correctly emphasizes that its tools perform real OS actions and are not sandboxed. This adds a concrete, optional defense-in-depth setup for users who want local pre-execution policy on MCP calls without changing Windows-MCP itself.

## Testing

Documentation-only change. The branch is based directly on current upstream `main` (`c3b59aeaf7fce6ef1793fec936e2713a70249272`) and differs by one file, +36/-0. The Windows-MCP command/config matches the current README, and the HOL Guard commands and `beforeMCPExecution` behavior were cross-checked against HOL Guard's current Cursor protection contract and setup guide.

No runtime code is changed.