### PR TITLE
fix(tree): prune dead UIA elements during traversal

### DIFF
--- a/src/windows_mcp/tree/cache_utils.py
+++ b/src/windows_mcp/tree/cache_utils.py
@@ -5,11 +5,30 @@ This module provides utilities for implementing UI Automation caching
 to reduce cross-process COM calls during tree traversal.
 """
 
-from windows_mcp.uia import CacheRequest, PropertyId, PatternId, TreeScope, Control
+from _ctypes import COMError
+
+from windows_mcp.uia import (
+    CacheRequest,
+    PropertyId,
+    PatternId,
+    TreeScope,
+    Control,
+    UIADeadElementError,
+    from_com_error,
+)
 from typing import Optional, Any
 import logging
 
 logger = logging.getLogger(__name__)
+
+
+def is_uia_dead_element_error(error: BaseException) -> bool:
+    """Return True for UIA failures that mean the element no longer exists."""
+    if isinstance(error, UIADeadElementError):
+        return True
+    if isinstance(error, COMError):
+        return isinstance(from_com_error(error), UIADeadElementError)
+    return False
 
 
 class CacheRequestFactory:
@@ -180,5 +199,15 @@ class CachedControlHelper:
             return children
             
         except Exception as e:
+            if is_uia_dead_element_error(e):
+                logger.debug("UIA element is no longer available; pruning stale subtree")
+                return []
+
             logger.debug(f"Failed to get cached children, falling back to regular access: {e}")
-            return node.GetChildren()
+            try:
+                return node.GetChildren()
+            except Exception as fallback_error:
+                if is_uia_dead_element_error(fallback_error):
+                    logger.debug("UIA element died during fallback; pruning stale subtree")
+                    return []
+                raise

--- a/src/windows_mcp/tree/service.py
+++ b/src/windows_mcp/tree/service.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 from windows_mcp.uia import Control, ComboBoxControl, DocumentControl, CheckBoxControl, EditControl, ButtonControl, SliderControl, ScrollPattern, WindowControl, ImageControl, Rect, ExpandCollapseState, ToggleState, PatternId, PropertyId, AccessibleRoleNames, TreeScope, ControlFromHandle, UIADeadElementError, from_com_error, TextPatternRangeEndpoint
 from windows_mcp.tree.config import INTERACTIVE_CONTROL_TYPE_NAMES, DOCUMENT_CONTROL_TYPE_NAMES, INFORMATIVE_CONTROL_TYPE_NAMES, DEFAULT_ACTIONS, INTERACTIVE_ROLES, THREAD_MAX_RETRIES, STRUCTURAL_CONTROL_TYPE_NAMES
 from windows_mcp.tree.views import TreeElementNode, ScrollElementNode, TextElementNode, Center, BoundingBox, TreeState, SemanticNode, _prune_structural, _reverse_children_order
-from windows_mcp.tree.cache_utils import CacheRequestFactory, CachedControlHelper
+from windows_mcp.tree.cache_utils import (
+    CacheRequestFactory,
+    CachedControlHelper,
+    is_uia_dead_element_error,
+)
 from windows_mcp.tree.budget import TreeElementBudget, resolve_max_tree_elements
 from windows_mcp.tree.utils import random_point_within_bounding_box
 from windows_mcp.tree import ia2 as ia2_traversal
@@ -811,6 +815,9 @@ class Tree:
                 e,
             )
         except Exception as e:
+            if is_uia_dead_element_error(e):
+                logger.debug("Skipping dead UIA subtree in '%s': %s", window_name, e)
+                return
             logger.error(f"Error in tree_traversal: {e}", exc_info=True)
             raise
 

--- a/tests/test_tree_cache_utils.py
+++ b/tests/test_tree_cache_utils.py
@@ -1,0 +1,52 @@
+from _ctypes import COMError
+from unittest.mock import MagicMock
+
+from windows_mcp.tree.cache_utils import CachedControlHelper
+
+
+UIA_E_ELEMENTNOTAVAILABLE = -2147220991
+
+
+def _cache_request():
+    request = MagicMock()
+    clone = MagicMock()
+    request.Clone.return_value = clone
+    clone.check_request = object()
+    return request
+
+
+def _stale_element_error():
+    return COMError(
+        UIA_E_ELEMENTNOTAVAILABLE,
+        "An event was unable to invoke any of the subscribers",
+        (None, None, None, 0, None),
+    )
+
+
+def test_unavailable_element_skips_regular_children_fallback():
+    node = MagicMock()
+    node.Element.BuildUpdatedCache.side_effect = _stale_element_error()
+
+    children = CachedControlHelper.get_cached_children(node, _cache_request())
+
+    assert children == []
+    node.GetChildren.assert_not_called()
+
+
+def test_unavailable_element_during_fallback_is_pruned():
+    node = MagicMock()
+    node.Element.BuildUpdatedCache.side_effect = RuntimeError("cache provider failed")
+    node.GetChildren.side_effect = _stale_element_error()
+
+    children = CachedControlHelper.get_cached_children(node, _cache_request())
+
+    assert children == []
+
+
+def test_unexpected_cache_failure_still_uses_regular_children():
+    node = MagicMock()
+    expected = [MagicMock(), MagicMock()]
+    node.Element.BuildUpdatedCache.side_effect = RuntimeError("cache provider failed")
+    node.GetChildren.return_value = expected
+
+    assert CachedControlHelper.get_cached_children(node, _cache_request()) == expected

--- a/tests/test_tree_service.py
+++ b/tests/test_tree_service.py
@@ -1,4 +1,6 @@
+from _ctypes import COMError
 from unittest.mock import MagicMock
+
 import pytest
 from windows_mcp.desktop.views import Size
 from windows_mcp.tree.budget import TreeElementBudget
@@ -181,6 +183,27 @@ class TestTreeTraversal:
 
         assert interactive_nodes == []
         assert semantic_root.children == []
+
+    def test_stale_uia_subtree_is_pruned(self, tree_instance):
+        class StaleNode:
+            @property
+            def CachedIsOffscreen(self):
+                raise COMError(
+                    -2147220991,
+                    "An event was unable to invoke any of the subscribers",
+                    (None, None, None, 0, None),
+                )
+
+        tree_instance.tree_traversal(
+            StaleNode(),
+            Rect(0, 0, 200, 200),
+            "Window",
+            False,
+            [],
+            [],
+            [],
+            [],
+        )
 
 
 def _make_button_child(name: str, left: int) -> MagicMock:


### PR DESCRIPTION
## Summary

Fixes stale/dead UI Automation elements aborting `Snapshot` tree traversal.

- reuse the existing `UIADeadElementError` / `from_com_error()` classification;
- prune a dead element immediately when `BuildUpdatedCache()` reports it is gone instead of retrying `GetChildren()` on the same stale node;
- also prune when the regular child-access fallback discovers that the element died;
- defensively skip a dead subtree when another cached property access fails during `tree_traversal()`;
- preserve the existing fallback and exception behavior for unrelated errors.

This keeps a transiently disappearing UI node from escalating into repeated full-window retries while allowing traversal of unaffected siblings/windows to continue.

Closes #393.

## Tests

Regression tests cover:

- dead element during `BuildUpdatedCache()` does not call `GetChildren()`;
- dead element during regular fallback is pruned;
- unrelated cache failures still use the regular fallback;
- dead property access during `tree_traversal()` prunes the subtree rather than escaping.

Evidence:

- before patch: focused cache tests reproduced the defect (`2 failed, 1 passed`);
- after patch: targeted tree tests `21 passed`;
- full local suite: `508 passed`.

Local verification used Python 3.13.5 because that is the installed Windows-MCP runtime on the reproducing host. The repository CI workflow will independently run the suite on its required Python 3.14 environment.
