### PR TITLE
fix: keep the server alive when the watchdog cannot start (#374)

### DIFF
--- a/src/windows_mcp/__main__.py
+++ b/src/windows_mcp/__main__.py
@@ -199,6 +199,35 @@ def _exit_missing_dependency(exc: ModuleNotFoundError) -> NoReturn:
     sys.exit(1)
 
 
+def _start_watchdog(desktop):
+    """Create and start the UIA WatchDog, or return None if it is unavailable.
+
+    The watchdog only refreshes cached UI state, but importing it builds COM
+    interface wrappers at module scope. A transient codegen or COM failure
+    there used to abort startup and take every tool down with it, so failures
+    degrade to running without a watchdog instead. See #374 for the
+    comtypes.gen generation race and #332 for the COM failures.
+    """
+    if not _watchdog_enabled():
+        logger.debug("WatchDog disabled via WINDOWS_MCP_WATCHDOG")
+        return None
+
+    watchdog = None
+    try:
+        # Imported lazily so a disabled watchdog never loads comtypes.
+        from windows_mcp.watchdog.service import WatchDog
+
+        watchdog = WatchDog()
+        watchdog.set_focus_callback(desktop.tree.on_focus_change)
+        watchdog.start()
+        return watchdog
+    except Exception:
+        logger.warning("WatchDog unavailable; continuing without it", exc_info=True)
+        if watchdog is not None:
+            watchdog.stop()
+        return None
+
+
 def _build_mcp() -> FastMCP:
     """Create the MCP server instance."""
     global _mcp
@@ -223,19 +252,9 @@ def _build_mcp() -> FastMCP:
         desktop = Desktop()
         screen_size = desktop.get_screen_size()
 
-        if _watchdog_enabled():
-            # Imported lazily so a disabled watchdog never loads comtypes.
-            from windows_mcp.watchdog.service import WatchDog
-
-            watchdog = WatchDog()
-            watchdog.set_focus_callback(desktop.tree.on_focus_change)
-        else:
-            watchdog = None
-            logger.debug("WatchDog disabled via WINDOWS_MCP_WATCHDOG")
+        watchdog = _start_watchdog(desktop)
 
         try:
-            if watchdog:
-                watchdog.start()
             logger.debug("Server started, entering main loop")
             yield
         finally:

--- a/tests/test_watchdog_degradation.py
+++ b/tests/test_watchdog_degradation.py
@@ -1,0 +1,145 @@
+"""Regression tests for issue #374 — a failing watchdog must not kill startup.
+
+`windows_mcp/watchdog/event_handlers.py` builds the UIA client at module scope
+and evaluates `UIA.IUIAutomation*EventHandler` when the handler classes are
+created, so merely importing the watchdog constructs COM. When the comtypes
+generated-module cache is mid-regeneration, that import raises and used to
+abort the whole server: every tool went down because an optional component
+could not start.
+
+The watchdog only refreshes cached UI state, and is already optional via
+WINDOWS_MCP_WATCHDOG, so any failure setting it up should degrade to running
+without it.
+"""
+
+import logging
+import sys
+import types
+
+import pytest
+
+import windows_mcp.__main__ as cli
+
+WATCHDOG_MODULE = "windows_mcp.watchdog.service"
+
+
+class FakeWatchDog:
+    """Stand-in for the real WatchDog, which would construct COM on import."""
+
+    def __init__(self, fail_on_start=False):
+        self.fail_on_start = fail_on_start
+        self.focus_callback = None
+        self.started = False
+        self.stopped = False
+
+    def set_focus_callback(self, callback):
+        self.focus_callback = callback
+
+    def start(self):
+        if self.fail_on_start:
+            raise OSError("STA thread refused to start")
+        self.started = True
+
+    def stop(self):
+        self.stopped = True
+
+
+class FakeDesktop:
+    def __init__(self):
+        self.tree = types.SimpleNamespace(on_focus_change=lambda sender: None)
+
+
+@pytest.fixture
+def desktop():
+    return FakeDesktop()
+
+
+@pytest.fixture(autouse=True)
+def watchdog_enabled(monkeypatch):
+    """Default to enabled; the real env var must not leak into these tests."""
+    monkeypatch.delenv("WINDOWS_MCP_WATCHDOG", raising=False)
+
+
+def install_fake_module(monkeypatch, watchdog_factory):
+    """Make `from windows_mcp.watchdog.service import WatchDog` yield a fake.
+
+    Importing the real module builds COM, which is the very thing under test.
+    """
+    module = types.ModuleType(WATCHDOG_MODULE)
+    module.WatchDog = watchdog_factory
+    monkeypatch.setitem(sys.modules, WATCHDOG_MODULE, module)
+
+
+class TestFailuresDegrade:
+    def test_import_failure_does_not_abort_startup(self, desktop, monkeypatch, caplog):
+        # A None entry in sys.modules makes the import statement raise
+        # ImportError, standing in for a half-written comtypes.gen module.
+        monkeypatch.setitem(sys.modules, WATCHDOG_MODULE, None)
+
+        with caplog.at_level(logging.WARNING, logger="windows_mcp.__main__"):
+            assert cli._start_watchdog(desktop) is None
+
+        assert any(r.levelno == logging.WARNING for r in caplog.records)
+
+    def test_construction_failure_does_not_abort_startup(self, desktop, monkeypatch, caplog):
+        def explode():
+            raise AttributeError(
+                "module 'comtypes.gen.UIAutomationClient' has no attribute 'IUIAutomation'"
+            )
+
+        install_fake_module(monkeypatch, explode)
+
+        with caplog.at_level(logging.WARNING, logger="windows_mcp.__main__"):
+            assert cli._start_watchdog(desktop) is None
+
+        assert any(r.levelno == logging.WARNING for r in caplog.records)
+
+    def test_failed_start_is_stopped_and_dropped(self, desktop, monkeypatch, caplog):
+        """A watchdog that constructs but fails to start must not be left running."""
+        built = []
+
+        def factory():
+            watchdog = FakeWatchDog(fail_on_start=True)
+            built.append(watchdog)
+            return watchdog
+
+        install_fake_module(monkeypatch, factory)
+
+        with caplog.at_level(logging.WARNING, logger="windows_mcp.__main__"):
+            assert cli._start_watchdog(desktop) is None
+
+        assert built[0].stopped, "a half-started watchdog must be stopped"
+
+
+class TestHealthyPath:
+    def test_watchdog_is_wired_and_started(self, desktop, monkeypatch):
+        install_fake_module(monkeypatch, FakeWatchDog)
+
+        watchdog = cli._start_watchdog(desktop)
+
+        assert isinstance(watchdog, FakeWatchDog)
+        assert watchdog.started
+        assert watchdog.focus_callback == desktop.tree.on_focus_change
+
+    def test_no_warning_when_healthy(self, desktop, monkeypatch, caplog):
+        install_fake_module(monkeypatch, FakeWatchDog)
+
+        with caplog.at_level(logging.WARNING, logger="windows_mcp.__main__"):
+            cli._start_watchdog(desktop)
+
+        assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+
+class TestDisabled:
+    @pytest.mark.parametrize("value", ["off", "0", "false", "no", "disabled", "OFF", " off "])
+    def test_disabled_never_imports_the_watchdog(self, desktop, monkeypatch, value):
+        monkeypatch.setenv("WINDOWS_MCP_WATCHDOG", value)
+        # Would raise ImportError if the disabled path tried to import at all.
+        monkeypatch.setitem(sys.modules, WATCHDOG_MODULE, None)
+
+        assert cli._start_watchdog(desktop) is None
+
+    def test_enabled_by_default(self, desktop, monkeypatch):
+        install_fake_module(monkeypatch, FakeWatchDog)
+
+        assert cli._start_watchdog(desktop) is not None


### PR DESCRIPTION
Closes #374. Refs #332.

### The reported race is already fixed

#374 reports startup dying with `AttributeError: module 'comtypes.gen.UIAutomationClient' has no attribute 'IUIAutomation'` when two interpreters generate the comtypes wrapper cache at once. That race was closed by 5114714 (2026-07-31, PR #358), which predates the report — the reporter's quoted retry loop calls `comtypes.client.GetModule` directly, so their checkout is older.

Measured here against a cleared cache with concurrent interpreters:

| path | result |
|---|---|
| pre-5114714 (as reported) | **22 of 24 processes died** — the exact `AttributeError`, plus `SyntaxError` from torn files |
| current `main` | **72 of 72 survived** at 8- and 16-way concurrency, zero failures |

I also probed six cache-corruption scenarios — truncated, empty, renamed attribute, and guaranteed-invalid Python in both the friendly and wrapper modules. All self-healed, because comtypes' own `_get_existing_module` catches broad `Exception` and regenerates. So the narrow `except (ImportError, AttributeError)` in `safe_get_module` is not a practical gap.

### What this PR actually fixes

The reporter's first suggestion was still open, and it is the part that turned a transient glitch into a dead server.

`windows_mcp/watchdog/event_handlers.py` builds the UIA client at module scope and evaluates `UIA.IUIAutomation*EventHandler` when its three handler classes are created, so *importing* the watchdog constructs COM. That import sat unguarded in the lifespan, so any failure propagated out and aborted startup — all 20 tools lost because an optional component could not start.

`_start_watchdog()` now degrades instead: a failing import, construction, or start logs a warning and the server runs without a watchdog, which is exactly the state `WINDOWS_MCP_WATCHDOG=off` already produces. A watchdog that constructs but then fails to start is stopped rather than left half-running.

### On the reporter's fourth point

The nested interpreters are not our code. On this machine `.venv\Scripts\python.exe -c "import time; time.sleep(6)"` also shows two processes while the base interpreter shows one — it is a uv venv trampoline. The extra process is a ~3 MB, 2-thread stub that never imports anything, so it never participates in codegen, and `python -m windows_mcp` shows the same doubling. The concurrent generation they hit almost certainly came from the host starting multiple server instances, which is the #357 scenario the lock was built for.

### Testing

13 new tests in `tests/test_watchdog_degradation.py`: import failure, construction failure, a half-started watchdog being stopped, healthy wiring, and the disabled path never importing at all.

Verified on the real runtime surface, not just in unit tests — the actual stdio server was started with the watchdog import poisoned, and it completed `initialize` + `tools/list` serving **all 20 tools**, logged the warning, and exited 0. The healthy path is unchanged and logs no warning.

> Note, unrelated to this PR: `tests/test_snapshot_display_filter.py::TestDisplayFiltering::test_get_state_region_takes_precedence_over_display` fails on `main` on any single-monitor machine. It mocks two 1920-wide displays but not `get_screen_box()`, so the region check runs against the real virtual screen. Worth a separate fix.
