### PR TITLE
fix: back off when the watchdog rebuild is triggered by degradation

### DIFF
--- a/src/windows_mcp/watchdog/service.py
+++ b/src/windows_mcp/watchdog/service.py
@@ -9,6 +9,7 @@ from threading import Thread, Event
 import comtypes.client
 import comtypes
 import logging
+import time
 
 from .event_handlers import (
     FocusChangedEventHandler,
@@ -25,6 +26,12 @@ logger.setLevel(logging.INFO)
 # the pump loop, so we detect it from the callback side instead.
 FAIL_THRESHOLD = 5
 MAX_BACKOFF_SECONDS = 30.0
+
+# How long a run must survive before its exit is treated as a one-off rather
+# than a symptom of a still-broken environment. Below this, the backoff keeps
+# growing, so a UIA stack that degrades immediately on every rebuild is retried
+# ever more slowly instead of churning COM clients at 1 Hz forever.
+HEALTHY_RUN_SECONDS = 60.0
 
 
 class WatchDog:
@@ -127,6 +134,7 @@ class WatchDog:
         backoff = 1.0
         while self.is_running.is_set():
             comtypes.CoInitialize()
+            started = time.monotonic()
             try:
                 self.uia = self._create_uia()
                 self._needs_rebuild.clear()
@@ -134,12 +142,19 @@ class WatchDog:
                 self._structure_fail_count = 0
                 self._property_fail_count = 0
                 self._event_loop()
-                backoff = 1.0  # clean exit (stopped or rebuild requested)
             except Exception as e:
                 logger.warning(f"WatchDog degraded, rebuilding UIA client: {e}")
             finally:
                 self._teardown_handlers()
                 comtypes.CoUninitialize()
+
+            # Only a run that lasted earns a reset. A rebuild requested seconds
+            # after starting means the environment is still broken, and
+            # resetting here would retry at 1 Hz indefinitely -- rebuilding the
+            # COM client and logging a warning every second, in exactly the
+            # degraded state this backoff exists to damp.
+            if time.monotonic() - started >= HEALTHY_RUN_SECONDS:
+                backoff = 1.0
 
             if self.is_running.is_set():
                 self.is_running.wait(backoff)

--- a/tests/test_watchdog_backoff.py
+++ b/tests/test_watchdog_backoff.py
@@ -1,0 +1,140 @@
+"""Regression tests for issue #332 — backoff must apply to degraded rebuilds.
+
+The watchdog rebuilds its UIA client when the focus pipeline goes stale, which
+`_event_loop` signals by returning with `_needs_rebuild` set. That return was
+treated as a clean exit and reset the backoff to 1 second, so an environment
+that degrades immediately on every rebuild was retried once a second forever —
+churning COM clients and emitting a warning per second, which is the log flood
+in the report. Backoff now only resets after a run that actually lasted.
+"""
+
+import time
+import types
+
+import pytest
+
+from windows_mcp.watchdog import service as watchdog_service
+from windows_mcp.watchdog.service import MAX_BACKOFF_SECONDS, WatchDog
+
+
+@pytest.fixture
+def watchdog(monkeypatch):
+    """A WatchDog with every COM touchpoint stubbed out."""
+    # __init__ grabs the UIA singleton, which would build COM.
+    monkeypatch.setattr(
+        watchdog_service._AutomationClient,
+        "instance",
+        classmethod(lambda cls: types.SimpleNamespace(UIAutomationCore=object())),
+    )
+    monkeypatch.setattr(watchdog_service.comtypes, "CoInitialize", lambda: None)
+    monkeypatch.setattr(watchdog_service.comtypes, "CoUninitialize", lambda: None)
+
+    watchdog = WatchDog()
+    monkeypatch.setattr(watchdog, "_create_uia", lambda: object())
+    monkeypatch.setattr(watchdog, "_teardown_handlers", lambda: None)
+    return watchdog
+
+
+def run_capturing_waits(watchdog, monkeypatch, event_loop):
+    """Drive _run synchronously, recording what it would have slept."""
+    waits = []
+    monkeypatch.setattr(watchdog, "_event_loop", event_loop)
+    monkeypatch.setattr(
+        watchdog.is_running, "wait", lambda timeout: waits.append(timeout) or False
+    )
+    watchdog.is_running.set()
+    watchdog._run()
+    return waits
+
+
+class TestDegradedRebuildBacksOff:
+    def test_immediate_degradation_escalates(self, watchdog, monkeypatch):
+        """The reported failure mode: rebuild requested as soon as each run starts."""
+        runs = {"n": 0}
+
+        def event_loop():
+            runs["n"] += 1
+            watchdog._needs_rebuild.set()  # what FAIL_THRESHOLD COMErrors do
+            if runs["n"] >= 5:
+                watchdog.is_running.clear()
+
+        waits = run_capturing_waits(watchdog, monkeypatch, event_loop)
+
+        assert waits == [1.0, 2.0, 4.0, 8.0], "a degraded rebuild must not reset backoff"
+
+    def test_backoff_is_capped(self, watchdog, monkeypatch):
+        runs = {"n": 0}
+
+        def event_loop():
+            runs["n"] += 1
+            watchdog._needs_rebuild.set()
+            if runs["n"] >= 12:
+                watchdog.is_running.clear()
+
+        waits = run_capturing_waits(watchdog, monkeypatch, event_loop)
+
+        assert max(waits) == MAX_BACKOFF_SECONDS
+        assert waits[-1] == MAX_BACKOFF_SECONDS
+
+    def test_exception_path_still_backs_off(self, watchdog, monkeypatch):
+        runs = {"n": 0}
+
+        def event_loop():
+            runs["n"] += 1
+            if runs["n"] >= 4:
+                watchdog.is_running.clear()
+            raise OSError("pump exploded")
+
+        waits = run_capturing_waits(watchdog, monkeypatch, event_loop)
+
+        assert waits == [1.0, 2.0, 4.0]
+
+
+class TestHealthyRunResetsBackoff:
+    def test_a_run_that_lasted_resets_the_backoff(self, watchdog, monkeypatch):
+        """An intermittent glitch after a long healthy run should retry promptly."""
+        monkeypatch.setattr(watchdog_service, "HEALTHY_RUN_SECONDS", 0.05)
+        runs = {"n": 0}
+
+        def event_loop():
+            runs["n"] += 1
+            if runs["n"] == 2:
+                time.sleep(0.06)  # this run survived long enough to count
+            watchdog._needs_rebuild.set()
+            if runs["n"] >= 3:
+                watchdog.is_running.clear()
+
+        waits = run_capturing_waits(watchdog, monkeypatch, event_loop)
+
+        assert waits == [1.0, 1.0], "a long run should return the retry delay to 1s"
+
+    def test_stopping_does_not_wait(self, watchdog, monkeypatch):
+        def event_loop():
+            watchdog.is_running.clear()
+
+        waits = run_capturing_waits(watchdog, monkeypatch, event_loop)
+
+        assert waits == []
+
+
+class TestClientIsRebuiltEachCycle:
+    def test_every_cycle_gets_a_fresh_client_and_clean_counters(self, watchdog, monkeypatch):
+        """#334's contract: never reuse a client that just reported failure."""
+        clients = []
+        monkeypatch.setattr(watchdog, "_create_uia", lambda: clients.append(object()) or clients[-1])
+        runs = {"n": 0}
+        seen_counts = []
+
+        def event_loop():
+            runs["n"] += 1
+            seen_counts.append(watchdog._focus_fail_count)
+            watchdog._focus_fail_count = 99  # simulate failures during the run
+            watchdog._needs_rebuild.set()
+            if runs["n"] >= 3:
+                watchdog.is_running.clear()
+
+        run_capturing_waits(watchdog, monkeypatch, event_loop)
+
+        assert len(clients) == 3, "each cycle must build its own client"
+        assert len(set(map(id, clients))) == 3
+        assert seen_counts == [0, 0, 0], "failure counters must reset per cycle"


### PR DESCRIPTION
Refs #332. This is a bug in the recovery loop added by #334, not the terminal crash — see the caveat at the bottom.

### The bug

`_run` reset `backoff = 1.0` on any clean return from `_event_loop`, with the comment *"clean exit (stopped or rebuild requested)"*. But a rebuild requested by `FAIL_THRESHOLD` consecutive `COMError`s returns exactly that way — `_event_loop` exits normally with `_needs_rebuild` set. Treating that as clean means the exponential backoff only ever applied to the exception path.

The consequence in the environment #332 describes, where the focus pipeline is persistently degraded:

1. five focus events fail, each logging at DEBUG
2. `request_rebuild()` fires
3. `_event_loop` returns, logging `WatchDog event pipeline degraded, rebuilding UIA client` at WARNING
4. backoff resets to 1.0, waits one second
5. a fresh `IUIAutomation` client is built and immediately degrades again

Repeat forever, once a second. That is the "thousands of identical lines" in the original report, plus a COM client constructed and torn down every second — churn that plausibly contributes to the state collapse rather than damping it.

### The fix

Reset the backoff only after a run that survived `HEALTHY_RUN_SECONDS` (60s). An intermittent glitch after hours of healthy operation still retries in one second, as intended; an environment that degrades the moment it rebuilds escalates 1, 2, 4, 8 … up to the existing 30s cap.

### Verification

Six tests in `tests/test_watchdog_backoff.py` drive `_run` directly with every COM touchpoint stubbed, capturing what it would have slept.

Checked against the pre-fix code, which is how the diagnosis was confirmed rather than assumed:

```
before:  waits == [1.0, 1.0, 1.0, 1.0]        # never escalates
after:   waits == [1.0, 2.0, 4.0, 8.0]        # and caps at 30.0
```

Twelve consecutive immediate degradations produced twelve 1.0s waits before, and reach the 30s cap now. The exception path, the "long healthy run resets backoff" path, the stop path, and #334's contract that each cycle builds a fresh client with clean failure counters are all covered too.

Full suite: 587 passed.

### What this does not fix

The terminal `-2147418113` / `E_UNEXPECTED` crash from the original report is untouched. That is a native access violation during `PumpEvents`, which no Python `except` can catch, and isolating the server from it needs the watchdog moved out of process. This change reduces how hard and how often the watchdog hammers a collapsing UIA stack on the way there, and makes the degradation legible in the log instead of drowning it — but #332 should stay open for the out-of-process work.
