### PR TITLE
fix: make the UIA focus watchdog opt-in

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ The codebase follows a layered service architecture under `src/windows_mcp/`:
 | `ANONYMIZED_TELEMETRY` | `true` | Set to `false` to disable PostHog telemetry. Checked in `__main__.py` and `infrastructure/analytics.py`. |
 | `POSTHOG_API_KEY` | Project default | Override the PostHog project write key used for anonymous telemetry. Set to an empty string to skip PostHog client initialization. Checked in `infrastructure/analytics.py`. |
 | `POSTHOG_HOST` | `https://us.i.posthog.com` | Override the PostHog host for anonymous telemetry, such as for a self-hosted PostHog deployment. Checked in `infrastructure/analytics.py`. |
-| `WINDOWS_MCP_WATCHDOG` | _(enabled)_ | Set to `off`/`0`/`false`/`no`/`disabled` to skip starting the UIA focus WatchDog thread. Any other value, including unset, leaves it running. Resolved in `__main__.py`. |
+| `WINDOWS_MCP_WATCHDOG` | _(off)_ | Set to `on`/`1`/`true`/`yes`/`enabled` to start the UIA focus WatchDog thread. Unset, or any other value, leaves it off. Opt-in because it only emits debug logging today but can crash the server via the UIA event pump (#332). Resolved in `__main__.py`. |
 | `WINDOWS_MCP_DEBUG` | `false` | Set to `1`/`true`/`yes`/`on` to enable debug mode. Checked in `config.py`. Also available as `--debug` CLI flag. |
 | `WINDOWS_MCP_DISABLE_FLASH` | _(off)_ | Set to `1`/`true`/`yes`/`on` to suppress the orange-red glowing border that briefly appears after every screenshot. Resolved in `desktop/flash_overlay.py`. |
 

--- a/README.md
+++ b/README.md
@@ -668,7 +668,7 @@ All variables are optional unless noted. Set them via the `env` key in `claude_d
 
 | Variable | Default | Description |
 |---|---|---|
-| `WINDOWS_MCP_WATCHDOG` | `true` | Set to `off`, `0`, `false`, `no`, or `disabled` (case-insensitive) to disable the UIA focus watchdog that keeps the accessibility tree current. On unstable UIA environments the watchdog can degrade after long uptime (e.g. across a sleep/resume or session change); disabling it trades away automatic focus tracking for stability — the accessibility tree still refreshes on-demand for tool calls. |
+| `WINDOWS_MCP_WATCHDOG` | `false` | Set to `on`, `1`, `true`, `yes`, or `enabled` (case-insensitive) to run the UIA focus watchdog. It is off by default because its only remaining effect is debug logging of focus changes, while it costs a background thread and a long-lived UIA event subscription that can crash the server on unstable UIA environments after long uptime (e.g. across a sleep/resume or session change). The accessibility tree is built on demand for every tool call either way, so tool behaviour is unaffected. |
 
 **Example `claude_desktop_config.json`:**
 

--- a/manifest.json
+++ b/manifest.json
@@ -73,9 +73,9 @@
     "watchdog": {
       "type": "boolean",
       "title": "UIA Focus WatchDog",
-      "description": "Run the UIAutomation focus watchdog that keeps the accessibility tree current. Disable if the watchdog degrades or crashes on unstable UIA environments after long uptime.",
+      "description": "Run the UIAutomation focus watchdog. Off by default: it currently only emits debug logging, while costing a background thread and a UIA event subscription that can crash the server on unstable UIA environments. Tool behaviour is unaffected either way.",
       "required": false,
-      "default": true
+      "default": false
     }
   },
   "tools": [

--- a/src/windows_mcp/__main__.py
+++ b/src/windows_mcp/__main__.py
@@ -163,20 +163,29 @@ class OptionsMiddleware:
 
 
 def _watchdog_enabled() -> bool:
-    """Whether the UIA focus WatchDog should run.
+    """Whether the UIA focus WatchDog should run. Off unless asked for.
 
-    Reads the ``WINDOWS_MCP_WATCHDOG`` environment variable. Disabling values
-    (case-insensitive, whitespace-trimmed): ``off``, ``0``, ``false``, ``no``,
-    ``disabled``. Anything else, including unset, keeps the watchdog enabled so
-    the default behavior is unchanged.
+    Reads the ``WINDOWS_MCP_WATCHDOG`` environment variable. Enabling values
+    (case-insensitive, whitespace-trimmed): ``on``, ``1``, ``true``, ``yes``,
+    ``enabled``. Unset, or anything else, leaves it off.
+
+    It is opt-in because it no longer earns its cost. Its only surviving
+    consumer is ``Tree.on_focus_change``, which debounces the event and writes
+    a debug log line -- the structure-change handling that once maintained
+    ``tree_state.interactive_nodes`` was removed, and nothing reads the focus
+    state it tracks. Against that, running it costs a dedicated STA thread, a
+    long-lived UIA event subscription, and exposure to a native access
+    violation in the event pump that takes the whole server down with no
+    Python traceback (#332). The accessibility tree is built on demand for
+    every tool call regardless, so leaving it off changes no tool behaviour.
 
     Returns:
         ``True`` when the watchdog should be started, ``False`` to skip it.
     """
     value = os.getenv("WINDOWS_MCP_WATCHDOG")
     if value is None:
-        return True
-    return value.strip().lower() not in {"off", "0", "false", "no", "disabled"}
+        return False
+    return value.strip().lower() in {"on", "1", "true", "yes", "enabled"}
 
 
 def _exit_missing_dependency(exc: ModuleNotFoundError) -> NoReturn:

--- a/tests/test_watchdog_degradation.py
+++ b/tests/test_watchdog_degradation.py
@@ -56,8 +56,8 @@ def desktop():
 
 @pytest.fixture(autouse=True)
 def watchdog_enabled(monkeypatch):
-    """Default to enabled; the real env var must not leak into these tests."""
-    monkeypatch.delenv("WINDOWS_MCP_WATCHDOG", raising=False)
+    """Opt in for these tests; the real env var must not leak in either way."""
+    monkeypatch.setenv("WINDOWS_MCP_WATCHDOG", "on")
 
 
 def install_fake_module(monkeypatch, watchdog_factory):
@@ -139,7 +139,15 @@ class TestDisabled:
 
         assert cli._start_watchdog(desktop) is None
 
-    def test_enabled_by_default(self, desktop, monkeypatch):
+    def test_off_by_default_never_imports_the_watchdog(self, desktop, monkeypatch):
+        """The watchdog is opt-in, so an unset env var must not even import it."""
+        monkeypatch.delenv("WINDOWS_MCP_WATCHDOG", raising=False)
+        monkeypatch.setitem(sys.modules, WATCHDOG_MODULE, None)
+
+        assert cli._start_watchdog(desktop) is None
+
+    def test_explicit_opt_in_starts_it(self, desktop, monkeypatch):
+        monkeypatch.setenv("WINDOWS_MCP_WATCHDOG", "on")
         install_fake_module(monkeypatch, FakeWatchDog)
 
         assert cli._start_watchdog(desktop) is not None

--- a/tests/test_watchdog_toggle.py
+++ b/tests/test_watchdog_toggle.py
@@ -1,21 +1,42 @@
-"""Tests for the WINDOWS_MCP_WATCHDOG opt-out switch (issue #332)."""
+"""Tests for the WINDOWS_MCP_WATCHDOG opt-in switch (issue #332).
+
+The watchdog used to default on. It now has to be asked for: its only
+surviving consumer is `Tree.on_focus_change`, which debounces and writes a
+debug log line, while running it costs an STA thread and a UIA event
+subscription that can take the whole server down via a native access
+violation in the pump.
+"""
+
+import pytest
 
 from windows_mcp import __main__ as wm
 
 
-class TestWatchdogEnabled:
-    def test_enabled_by_default_when_unset(self, monkeypatch):
+class TestOffByDefault:
+    def test_unset_leaves_it_off(self, monkeypatch):
         monkeypatch.delenv("WINDOWS_MCP_WATCHDOG", raising=False)
+        assert wm._watchdog_enabled() is False
+
+    @pytest.mark.parametrize(
+        "value", ["off", "0", "false", "no", "disabled", "OFF", "  False  ", "No", ""]
+    )
+    def test_disabling_and_unrecognised_values_stay_off(self, monkeypatch, value):
+        monkeypatch.setenv("WINDOWS_MCP_WATCHDOG", value)
+        assert wm._watchdog_enabled() is False, value
+
+
+class TestExplicitOptIn:
+    @pytest.mark.parametrize(
+        "value", ["on", "1", "true", "yes", "enabled", "ON", "  True  ", "Yes"]
+    )
+    def test_enabling_values_turn_it_on(self, monkeypatch, value):
+        monkeypatch.setenv("WINDOWS_MCP_WATCHDOG", value)
+        assert wm._watchdog_enabled() is True, value
+
+    def test_manifest_boolean_maps_through(self, monkeypatch):
+        """manifest.json passes the user_config boolean through as a string."""
+        monkeypatch.setenv("WINDOWS_MCP_WATCHDOG", "true")
         assert wm._watchdog_enabled() is True
 
-    def test_disabling_values_turn_it_off(self, monkeypatch):
-        for value in ["off", "0", "false", "no", "disabled", "OFF", "  False  ", "No"]:
-            monkeypatch.setenv("WINDOWS_MCP_WATCHDOG", value)
-            assert wm._watchdog_enabled() is False, value
-
-    def test_other_values_keep_it_on(self, monkeypatch):
-        # Anything not in the disabling set (including empty string) keeps the
-        # default-on behavior unchanged.
-        for value in ["on", "1", "true", "yes", "enabled", ""]:
-            monkeypatch.setenv("WINDOWS_MCP_WATCHDOG", value)
-            assert wm._watchdog_enabled() is True, value
+        monkeypatch.setenv("WINDOWS_MCP_WATCHDOG", "false")
+        assert wm._watchdog_enabled() is False


### PR DESCRIPTION
Refs #332. **Behaviour change:** the UIA focus watchdog no longer starts by default.

### Why

While working #332 I went looking for what the watchdog actually feeds, and the answer is: nothing. Its only consumer in production is `Tree.on_focus_change`, and that method in full debounces duplicate events and writes one DEBUG log line. `_last_focus_event` is read nowhere except its own debounce check, and `set_structure_callback` / `set_property_callback` are called from nowhere at all.

Git history explains it. There used to be a `_on_structure_change` doing the real work — mutating `tree_state.interactive_nodes`, adding nodes on `ChildAdded`, removing them on `ChildRemoved`, rebuilding subtrees on `ChildrenInvalidated`, updating them on `ChildrenReordered`. That was deleted, and the log-only `_on_property_change` went with it. What survives is the delivery mechanism with its payload removed.

So the current cost/benefit is a dedicated STA thread, a long-lived UIA event subscription, COM construction at import time (the hazard #398 had to guard), and exposure to the native access violation in `PumpEvents` that kills the entire server with no Python traceback — in exchange for a debug log line.

### What changed

`WINDOWS_MCP_WATCHDOG` becomes opt-in: `on`, `1`, `true`, `yes` or `enabled` starts it, unset or anything else leaves it off. `manifest.json`'s `user_config` default flips to `false`, and its description no longer claims the watchdog "keeps the accessibility tree current" — untrue since the structure-change code was removed. README and CLAUDE.md updated to match.

Anyone relying on the watchdog can still turn it on, and #399's backoff fix means it behaves better if they do.

### Verification

The accessibility tree is built on demand for every tool call, so nothing about tool behaviour depends on this. Confirmed against the real stdio server rather than assumed — `initialize` + `tools/list` under both settings:

```
                   env |  _watchdog_enabled() | threads in server
                 unset |                False | 32
                    on |                 True | 36
                   off |                False | -
                  true |                 True | -
                 false |                False | -
```

All 20 tools served either way, clean exit both times; the default genuinely does not start the thread, and the manifest's boolean maps through correctly in both directions.

Full suite: 604 passed.

### On #332

This does not "fix" the crash so much as stop shipping the thing that causes it to every user by default, which for a component with no current function is the honest trade. If the tree-cache maintenance is ever restored, the watchdog can be turned back on — ideally on a polling loop rather than native callbacks, so an access violation in UIA cannot take the server down. I'd suggest keeping #332 open until then.
